### PR TITLE
try fix github actions

### DIFF
--- a/.github/workflows/auto-commit.yml
+++ b/.github/workflows/auto-commit.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install Hub CLI
-        uses: geertvdc/setup-hub@master
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run auto_committer.sh


### PR DESCRIPTION
the action to install hub CLI is no longer automatically compatible
with the current github actions.

The current github actions discourages the use of  and the command
is only allow if we turn on an unsafe flag.

consequently, on the action's github issues page, there exist a claim that
hub cli commands are available in actions without installing. Thus this commit removes
the installation of hub cli to test this claim