### PR TITLE
Fix Homebrew install commands in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Install one of the previous versions by tapping this repository and running the 
 
 ## Installing one of the versions here
 
-```
+```bash
 brew tap isen-ng/dotnet-sdk-versions
 brew install --cask <version>
 
@@ -42,7 +42,7 @@ dependencies when uninstalling a particular version as it will cause other versi
 
 If there is a need to purge these dependencies, use the `zap` flag:
 
-```
+```bash
 brew uninstall --zap --cask <version>
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Install one of the previous versions by tapping this repository and running the 
 
 ## Installing one of the versions here
 
-```bash
+```
 brew tap isen-ng/dotnet-sdk-versions
 brew install --cask <version>
 
@@ -42,7 +42,7 @@ dependencies when uninstalling a particular version as it will cause other versi
 
 If there is a need to purge these dependencies, use the `zap` flag:
 
-```bash
+```
 brew uninstall --zap --cask <version>
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install one of the previous versions by tapping this repository and running the 
 
 ```
 brew tap isen-ng/dotnet-sdk-versions
-brew cask install <version>
+brew install --cask <version>
 
 dotnet --list-sdks
 ```
@@ -40,10 +40,10 @@ dotnet --list-sdks
 Because the dotnet packages uses shared dependencies between different versions, it is unwise to delete these 
 dependencies when uninstalling a particular version as it will cause other versions not to work. 
 
-If there is a need to purge these dependencies, use the `zap` command:
+If there is a need to purge these dependencies, use the `zap` flag:
 
 ```
-brew cask zap <version>
+brew uninstall --zap --cask <version>
 ```
 
 *Important*: Uninstalling the offical version will also remove these dependencies, so you'll need to reinstall the particular version you want to use again.


### PR DESCRIPTION
`brew cask install` and `brew cask zap` were disabled [in Homebrew 2.7.0](https://brew.sh/2020/12/21/homebrew-2.7.0/) (Homebrew/brew#10056).