### PR TITLE
Add .NET SDK 5.0.4xx

### DIFF
--- a/Casks/dotnet-sdk5-0-400.rb
+++ b/Casks/dotnet-sdk5-0-400.rb
@@ -1,0 +1,30 @@
+cask "dotnet-sdk5-0-400" do
+  version "5.0.402,5.0.11"
+  sha256 "525d0ff470e3d0e16b06787e72bdaf34df385007ee9125aa6f30eced69ef6a61"
+
+  url "https://download.visualstudio.microsoft.com/download/pr/88bc1553-e90f-4a4f-9574-65d9a5065cd2/1d5646e1abb8b4d4a61ba0b0be976047/dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
+  name ".NET Core SDK #{version.before_comma}"
+  desc "This cask follows releases from https://github.com/dotnet/core/tree/master"
+  homepage "https://www.microsoft.com/net/core#macos"
+
+  livecheck do
+    skip "See https://github.com/isen-ng/homebrew-dotnet-sdk-versions"
+  end
+
+  depends_on macos: "> :sierra"
+
+  pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
+
+  uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"
+
+  zap trash:   ["~/.dotnet", "~/.nuget"],
+      pkgutil: [
+        "com.microsoft.dotnet.hostfxr.#{version.after_comma}.component.osx.x64",
+        "com.microsoft.dotnet.sharedframework.Microsoft.NETCore.App.#{version.after_comma}.component.osx.x64",
+        "com.microsoft.dotnet.sharedhost.component.osx.x64",
+      ]
+
+  caveats "Uninstalling the offical dotnet-sdk casks will remove the shared runtime dependencies, "\
+          "so you\'ll need to reinstall the particular version cask you want from this tap again "\
+          "for the `dotnet` command to work again."
+end

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ dotnet --list-sdks
 
 | Version             | DotNet SDK     | Remarks
 |---------------------|----------------|-----------
-| `dotnet-sdk5-0-200` | dotnet 5.0.207 | 
-| `dotnet-sdk3-1-400` | dotnet 3.1.413 | 
-| `dotnet-sdk3-1-300` | dotnet 3.1.302 | 
+| `dotnet-sdk5-0-400` | dotnet 5.0.402 |
+| `dotnet-sdk5-0-200` | dotnet 5.0.207 |
+| `dotnet-sdk3-1-400` | dotnet 3.1.413 |
+| `dotnet-sdk3-1-300` | dotnet 3.1.302 |
 | `dotnet-sdk3-1-200` | dotnet 3.1.202 |
 | `dotnet-sdk3-1-100` | dotnet 3.1.119 |
 | `dotnet-sdk3-0-100` | dotnet 3.0.103 |


### PR DESCRIPTION
As of writing, SDK 5.0.402 is the latest version.

The `auto_updater.sh` wouldn't fetch it until I added the formula.