### PR TITLE
Add dotnet-sdk6-0-100

### DIFF
--- a/Casks/dotnet-sdk6-0-100.rb
+++ b/Casks/dotnet-sdk6-0-100.rb
@@ -1,0 +1,30 @@
+cask "dotnet-sdk6-0-100" do
+  version "6.0.100,6.0.0"
+  sha256 "9203560506408d8f88774358b03cdcfcfa0495682fde6034b24f7ccaeddce2ef"
+
+  url "https://download.visualstudio.microsoft.com/download/pr/14a45451-4cc9-48e1-af69-0aff75891d09/ff6e83986a2a9a535015fb3104a90a1b/dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
+  name ".NET Core SDK #{version.before_comma}"
+  desc "This cask follows releases from https://github.com/dotnet/core/tree/master"
+  homepage "https://www.microsoft.com/net/core#macos"
+
+  livecheck do
+    skip "See https://github.com/isen-ng/homebrew-dotnet-sdk-versions"
+  end
+
+  depends_on macos: "> :sierra"
+
+  pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
+
+  uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"
+
+  zap trash:   ["~/.dotnet", "~/.nuget"],
+      pkgutil: [
+        "com.microsoft.dotnet.hostfxr.#{version.after_comma}.component.osx.x64",
+        "com.microsoft.dotnet.sharedframework.Microsoft.NETCore.App.#{version.after_comma}.component.osx.x64",
+        "com.microsoft.dotnet.sharedhost.component.osx.x64",
+      ]
+
+  caveats "Uninstalling the offical dotnet-sdk casks will remove the shared runtime dependencies, "\
+          "so you\'ll need to reinstall the particular version cask you want from this tap again "\
+          "for the `dotnet` command to work again."
+end

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ dotnet --list-sdks
 
 | Version             | DotNet SDK     | Remarks
 |---------------------|----------------|-----------
+| `dotnet-sdk6-0-100` | dotnet 6.0.100 |
 | `dotnet-sdk5-0-400` | dotnet 5.0.402 |
 | `dotnet-sdk5-0-200` | dotnet 5.0.208 |
 | `dotnet-sdk3-1-400` | dotnet 3.1.414 |


### PR DESCRIPTION
This PR adds support for .NET SDK 6.0 (6.0.100).

```
basilfx:homebrew-dotnet-sdk-versions/ (feature/dotnet-sdk6✗) $ dotnet --list-sdks
2.2.402 [/usr/local/share/dotnet/sdk]
3.1.414 [/usr/local/share/dotnet/sdk]
5.0.208 [/usr/local/share/dotnet/sdk]
5.0.402 [/usr/local/share/dotnet/sdk]
6.0.100 [/usr/local/share/dotnet/sdk]
```