### PR TITLE
Add symlink to the binary in all casks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,3 +76,9 @@ git push fork new-cask/dotnet-sdk-2.99.400
 brew update
 brew upgrade --cask dotnet-sdk2-1-400
 ```
+
+## Tapping a local path
+
+````
+brew tap isen-ng/dotnet-sdk-version $PWD
+```

--- a/Casks/dotnet-sdk2-1-400.rb
+++ b/Casks/dotnet-sdk2-1-400.rb
@@ -15,6 +15,10 @@ cask "dotnet-sdk2-1-400" do
 
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
+  postflight do
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+  end
+
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"
 
   zap trash:   ["~/.dotnet", "~/.nuget"],

--- a/Casks/dotnet-sdk2-1-400.rb
+++ b/Casks/dotnet-sdk2-1-400.rb
@@ -16,7 +16,7 @@ cask "dotnet-sdk2-1-400" do
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
   postflight do
-    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin/dotnet")
   end
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"

--- a/Casks/dotnet-sdk2-1-500.rb
+++ b/Casks/dotnet-sdk2-1-500.rb
@@ -15,6 +15,10 @@ cask "dotnet-sdk2-1-500" do
 
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
+  postflight do
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+  end
+
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"
 
   zap trash:   ["~/.dotnet", "~/.nuget"],

--- a/Casks/dotnet-sdk2-1-500.rb
+++ b/Casks/dotnet-sdk2-1-500.rb
@@ -16,7 +16,7 @@ cask "dotnet-sdk2-1-500" do
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
   postflight do
-    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin/dotnet")
   end
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"

--- a/Casks/dotnet-sdk2-1-800.rb
+++ b/Casks/dotnet-sdk2-1-800.rb
@@ -15,6 +15,10 @@ cask "dotnet-sdk2-1-800" do
 
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
+  postflight do
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+  end
+
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"
 
   zap trash:   ["~/.dotnet", "~/.nuget"],

--- a/Casks/dotnet-sdk2-1-800.rb
+++ b/Casks/dotnet-sdk2-1-800.rb
@@ -16,7 +16,7 @@ cask "dotnet-sdk2-1-800" do
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
   postflight do
-    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin/dotnet")
   end
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"

--- a/Casks/dotnet-sdk2-2-100.rb
+++ b/Casks/dotnet-sdk2-2-100.rb
@@ -15,6 +15,10 @@ cask "dotnet-sdk2-2-100" do
 
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
+  postflight do
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+  end
+
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"
 
   zap trash:   ["~/.dotnet", "~/.nuget"],

--- a/Casks/dotnet-sdk2-2-100.rb
+++ b/Casks/dotnet-sdk2-2-100.rb
@@ -16,7 +16,7 @@ cask "dotnet-sdk2-2-100" do
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
   postflight do
-    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin/dotnet")
   end
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"

--- a/Casks/dotnet-sdk2-2-200.rb
+++ b/Casks/dotnet-sdk2-2-200.rb
@@ -16,7 +16,7 @@ cask "dotnet-sdk2-2-200" do
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
   postflight do
-    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin/dotnet")
   end
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"

--- a/Casks/dotnet-sdk2-2-200.rb
+++ b/Casks/dotnet-sdk2-2-200.rb
@@ -15,6 +15,10 @@ cask "dotnet-sdk2-2-200" do
 
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
+  postflight do
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+  end
+
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"
 
   zap trash:   ["~/.dotnet", "~/.nuget"],

--- a/Casks/dotnet-sdk2-2-300.rb
+++ b/Casks/dotnet-sdk2-2-300.rb
@@ -15,6 +15,10 @@ cask "dotnet-sdk2-2-300" do
 
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
+  postflight do
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+  end
+
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"
 
   zap trash:   ["~/.dotnet", "~/.nuget"],

--- a/Casks/dotnet-sdk2-2-300.rb
+++ b/Casks/dotnet-sdk2-2-300.rb
@@ -16,7 +16,7 @@ cask "dotnet-sdk2-2-300" do
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
   postflight do
-    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin/dotnet")
   end
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"

--- a/Casks/dotnet-sdk2-2-400.rb
+++ b/Casks/dotnet-sdk2-2-400.rb
@@ -16,7 +16,7 @@ cask "dotnet-sdk2-2-400" do
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
   postflight do
-    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin/dotnet")
   end
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"

--- a/Casks/dotnet-sdk2-2-400.rb
+++ b/Casks/dotnet-sdk2-2-400.rb
@@ -11,22 +11,15 @@ cask "dotnet-sdk2-2-400" do
     skip "See https://github.com/isen-ng/homebrew-dotnet-sdk-versions/blob/master/CONTRIBUTING.md#automatic-updates"
   end
 
-  if MacOS.version <= :sierra
-    conflicts_with cask: [
-      "dotnet",
-      "dotnet-sdk",
-    ]
-  end
-
   depends_on macos: ">= :sierra"
 
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
-  uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64",
-            delete:  [
-              "/etc/paths.d/dotnet",
-              "/etc/paths.d/dotnet-cli-tools",
-            ]
+  postflight do
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+  end
+
+  uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"
 
   zap trash:   ["~/.dotnet", "~/.nuget"],
       pkgutil: [

--- a/Casks/dotnet-sdk3-0-100.rb
+++ b/Casks/dotnet-sdk3-0-100.rb
@@ -16,7 +16,7 @@ cask "dotnet-sdk3-0-100" do
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
   postflight do
-    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin/dotnet")
   end
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"

--- a/Casks/dotnet-sdk3-0-100.rb
+++ b/Casks/dotnet-sdk3-0-100.rb
@@ -15,6 +15,10 @@ cask "dotnet-sdk3-0-100" do
 
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
+  postflight do
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+  end
+
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"
 
   zap trash:   ["~/.dotnet", "~/.nuget"],

--- a/Casks/dotnet-sdk3-1-100.rb
+++ b/Casks/dotnet-sdk3-1-100.rb
@@ -15,6 +15,10 @@ cask "dotnet-sdk3-1-100" do
 
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
+  postflight do
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+  end
+
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"
 
   zap trash:   ["~/.dotnet", "~/.nuget"],

--- a/Casks/dotnet-sdk3-1-100.rb
+++ b/Casks/dotnet-sdk3-1-100.rb
@@ -16,7 +16,7 @@ cask "dotnet-sdk3-1-100" do
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
   postflight do
-    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin/dotnet")
   end
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"

--- a/Casks/dotnet-sdk3-1-200.rb
+++ b/Casks/dotnet-sdk3-1-200.rb
@@ -15,6 +15,10 @@ cask "dotnet-sdk3-1-200" do
 
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
+  postflight do
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+  end
+
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"
 
   zap trash:   ["~/.dotnet", "~/.nuget"],

--- a/Casks/dotnet-sdk3-1-200.rb
+++ b/Casks/dotnet-sdk3-1-200.rb
@@ -16,7 +16,7 @@ cask "dotnet-sdk3-1-200" do
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
   postflight do
-    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin/dotnet")
   end
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"

--- a/Casks/dotnet-sdk3-1-300.rb
+++ b/Casks/dotnet-sdk3-1-300.rb
@@ -15,6 +15,10 @@ cask "dotnet-sdk3-1-300" do
 
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
+  postflight do
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+  end
+
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"
 
   zap trash:   ["~/.dotnet", "~/.nuget"],

--- a/Casks/dotnet-sdk3-1-300.rb
+++ b/Casks/dotnet-sdk3-1-300.rb
@@ -16,7 +16,7 @@ cask "dotnet-sdk3-1-300" do
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
   postflight do
-    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin")
+    FileUtils.ln_sf("/usr/local/share/dotnet/dotnet", "#{HOMEBREW_PREFIX}/bin/dotnet")
   end
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"

--- a/Casks/dotnet-sdk3-1-400.rb
+++ b/Casks/dotnet-sdk3-1-400.rb
@@ -16,7 +16,7 @@ cask "dotnet-sdk3-1-400" do
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
   postflight do
-    FileUtils.ln_sf("/usr/local/share/dotnet/x64/dotnet", "#{HOMEBREW_PREFIX}/bin")
+    FileUtils.ln_sf("/usr/local/share/dotnet/x64/dotnet", "#{HOMEBREW_PREFIX}/bin/dotnet")
   end
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"

--- a/Casks/dotnet-sdk3-1-400.rb
+++ b/Casks/dotnet-sdk3-1-400.rb
@@ -15,6 +15,10 @@ cask "dotnet-sdk3-1-400" do
 
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
+  postflight do
+    FileUtils.ln_sf("/usr/local/share/dotnet/x64/dotnet", "#{HOMEBREW_PREFIX}/bin")
+  end
+
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"
 
   zap trash:   ["~/.dotnet", "~/.nuget"],

--- a/Casks/dotnet-sdk5-0-200.rb
+++ b/Casks/dotnet-sdk5-0-200.rb
@@ -16,7 +16,7 @@ cask "dotnet-sdk5-0-200" do
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
   postflight do
-    FileUtils.ln_sf("/usr/local/share/dotnet/x64/dotnet", "#{HOMEBREW_PREFIX}/bin")
+    FileUtils.ln_sf("/usr/local/share/dotnet/x64/dotnet", "#{HOMEBREW_PREFIX}/bin/dotnet")
   end
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"

--- a/Casks/dotnet-sdk5-0-200.rb
+++ b/Casks/dotnet-sdk5-0-200.rb
@@ -8,12 +8,16 @@ cask "dotnet-sdk5-0-200" do
   homepage "https://www.microsoft.com/net/core#macos"
 
   livecheck do
-    skip "See https://github.com/isen-ng/homebrew-dotnet-sdk-versions"
+    skip "See https://github.com/isen-ng/homebrew-dotnet-sdk-versions/blob/master/CONTRIBUTING.md#automatic-updates"
   end
 
   depends_on macos: "> :sierra"
 
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
+
+  postflight do
+    FileUtils.ln_sf("/usr/local/share/dotnet/x64/dotnet", "#{HOMEBREW_PREFIX}/bin")
+  end
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"
 

--- a/Casks/dotnet-sdk5-0-400.rb
+++ b/Casks/dotnet-sdk5-0-400.rb
@@ -8,12 +8,16 @@ cask "dotnet-sdk5-0-400" do
   homepage "https://www.microsoft.com/net/core#macos"
 
   livecheck do
-    skip "See https://github.com/isen-ng/homebrew-dotnet-sdk-versions"
+    skip "See https://github.com/isen-ng/homebrew-dotnet-sdk-versions/blob/master/CONTRIBUTING.md#automatic-updates"
   end
 
   depends_on macos: "> :sierra"
 
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
+
+  postflight do
+    FileUtils.ln_sf("/usr/local/share/dotnet/x64/dotnet", "#{HOMEBREW_PREFIX}/bin")
+  end
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"
 

--- a/Casks/dotnet-sdk5-0-400.rb
+++ b/Casks/dotnet-sdk5-0-400.rb
@@ -16,7 +16,7 @@ cask "dotnet-sdk5-0-400" do
   pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
 
   postflight do
-    FileUtils.ln_sf("/usr/local/share/dotnet/x64/dotnet", "#{HOMEBREW_PREFIX}/bin")
+    FileUtils.ln_sf("/usr/local/share/dotnet/x64/dotnet", "#{HOMEBREW_PREFIX}/bin/dotnet")
   end
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.x64"

--- a/Casks/dotnet-sdk6-0-100.rb
+++ b/Casks/dotnet-sdk6-0-100.rb
@@ -2,6 +2,7 @@ cask "dotnet-sdk6-0-100" do
   version "6.0.100,6.0.0"
 
   arch = Hardware::CPU.intel? ? "x64" : "arm64"
+  link = Hardware::CPU.intel? ? "/usr/local/share/dotnet/x64/dotnet" : "/usr/local/share/dotnet/dotnet"
   sha256_x64 = "9203560506408d8f88774358b03cdcfcfa0495682fde6034b24f7ccaeddce2ef"
   sha256_arm64 = "df96e334b5ac10e9e4abccf81376f52da1ed0fb0ad3822709e3c27b8c0bfa01a"
   url_x64 = "https://download.visualstudio.microsoft.com/download/pr/14a45451-4cc9-48e1-af69-0aff75891d09/ff6e83986a2a9a535015fb3104a90a1b/dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
@@ -37,7 +38,9 @@ cask "dotnet-sdk6-0-100" do
         "com.microsoft.dotnet.sharedhost.component.osx.#{arch}",
       ]
 
-  caveats "Uninstalling the offical dotnet-sdk casks will remove the shared runtime dependencies, "\
+  caveats "This is an alternate version of dotnet-sdk so it will not be symlinked. If your `dotnet` is not already"\
+          "linked, you can run this to link it: `ln -s #{link} $(brew --prefix)/bin/dotnet`\n\n"\
+          "Uninstalling the offical dotnet-sdk casks will remove the shared runtime dependencies, "\
           "so you\'ll need to reinstall the particular version cask you want from this tap again "\
           "for the `dotnet` command to work again."
 end

--- a/Casks/dotnet-sdk6-0-100.rb
+++ b/Casks/dotnet-sdk6-0-100.rb
@@ -27,6 +27,7 @@ cask "dotnet-sdk6-0-100" do
   depends_on macos: "> :sierra"
 
   pkg "dotnet-sdk-#{version.before_comma}-osx-#{arch}.pkg"
+  installer script: "which dotnet || ln -s #{link} $(brew --prefix)/bin/dotnet"
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.#{arch}"
 

--- a/Casks/dotnet-sdk6-0-100.rb
+++ b/Casks/dotnet-sdk6-0-100.rb
@@ -21,7 +21,7 @@ cask "dotnet-sdk6-0-100" do
   homepage "https://www.microsoft.com/net/core#macos"
 
   livecheck do
-    skip "See https://github.com/isen-ng/homebrew-dotnet-sdk-versions"
+    skip "See https://github.com/isen-ng/homebrew-dotnet-sdk-versions/blob/master/CONTRIBUTING.md#automatic-updates"
   end
 
   depends_on macos: "> :sierra"

--- a/Casks/dotnet-sdk6-0-100.rb
+++ b/Casks/dotnet-sdk6-0-100.rb
@@ -29,7 +29,7 @@ cask "dotnet-sdk6-0-100" do
   pkg "dotnet-sdk-#{version.before_comma}-osx-#{arch}.pkg"
 
   postflight do
-    FileUtils.ln_sf("#{link}", "#{HOMEBREW_PREFIX}/bin")
+    FileUtils.ln_sf(link.to_s, "#{HOMEBREW_PREFIX}/bin/dotnet")
   end
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.#{arch}"

--- a/Casks/dotnet-sdk6-0-100.rb
+++ b/Casks/dotnet-sdk6-0-100.rb
@@ -27,7 +27,8 @@ cask "dotnet-sdk6-0-100" do
   depends_on macos: "> :sierra"
 
   pkg "dotnet-sdk-#{version.before_comma}-osx-#{arch}.pkg"
-  installer script: "which dotnet || ln -s #{link} $(brew --prefix)/bin/dotnet"
+
+  postflight script: "bash -c which dotnet || ln -s #{link} $(brew --prefix)/bin/dotnet"
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.#{arch}"
 

--- a/Casks/dotnet-sdk6-0-100.rb
+++ b/Casks/dotnet-sdk6-0-100.rb
@@ -28,7 +28,9 @@ cask "dotnet-sdk6-0-100" do
 
   pkg "dotnet-sdk-#{version.before_comma}-osx-#{arch}.pkg"
 
-  postflight script: "bash -c which dotnet || ln -s #{link} $(brew --prefix)/bin/dotnet"
+  postflight do
+    FileUtils.ln_sf("#{link}", "#{HOMEBREW_PREFIX}/bin")
+  end
 
   uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.before_comma}.component.osx.#{arch}"
 
@@ -40,9 +42,7 @@ cask "dotnet-sdk6-0-100" do
         "com.microsoft.dotnet.sharedhost.component.osx.#{arch}",
       ]
 
-  caveats "This is an alternate version of dotnet-sdk so it will not be symlinked. If your `dotnet` is not already"\
-          "linked, you can run this to link it: `ln -s #{link} $(brew --prefix)/bin/dotnet`\n\n"\
-          "Uninstalling the offical dotnet-sdk casks will remove the shared runtime dependencies, "\
+  caveats "Uninstalling the offical dotnet-sdk casks will remove the shared runtime dependencies, "\
           "so you\'ll need to reinstall the particular version cask you want from this tap again "\
           "for the `dotnet` command to work again."
 end


### PR DESCRIPTION
Forcefully add a symlink to the `dotnet` binary even if it exists by using `postflight` and a script.

The `binary` stanza is not used because homebrew will automatically try to link the executable in the stanza. If there were conflicting links by different casks (eg, different versions of dotnet-sdk casks trying to link the same `dotnet` binary),  the installation process will error out with a failure to link. At that point, the sdk is installed in a limbo state (brew thinks that it's not installed, but the files have already been extracted).

To avoid all of that drama, we will avoid using the `binary` stanza. Instead, we will manually, and forcefully create a symlink to the `dotnet` executable after the installation, in a `postflight` stanza.

Fixes #182
