### PR TITLE
Add dotnet-sdk7-0-100

### DIFF
--- a/Casks/dotnet-sdk7-0-100.rb
+++ b/Casks/dotnet-sdk7-0-100.rb
@@ -1,0 +1,45 @@
+cask "dotnet-sdk7-0-100" do
+  arch arm: "arm64", intel: "x64"
+
+  version "7.0.100,7.0.0"
+
+  sha256_x64 = "3311f8b5bf78cd8cbf2350a4385708ce3ac111333760835bb93dab98c5867b00"
+  sha256_arm64 = "9ea8807a2bd7db29bbad7a3ba235bffe0999bea4fd2b4deec9e71da8da309d17"
+  url_x64 = "https://download.visualstudio.microsoft.com/download/pr/11810c49-a615-40ec-b869-2eb2eae30f7b/4b0b7700fa0e8307b5f99c1d372d95bb/dotnet-sdk-#{version.csv.first}-osx-x64.pkg"
+  url_arm64 = "https://download.visualstudio.microsoft.com/download/pr/4f0bd204-39be-492a-be5e-4bda7f569963/b245763ad54175dd87e260e394ec9c0d/dotnet-sdk-#{version.csv.first}-osx-arm64.pkg"
+
+  on_intel do
+    sha256 sha256_x64
+    url url_x64
+  end
+  on_arm do
+    sha256 sha256_arm64
+    url url_arm64
+  end
+
+  name ".NET Core SDK #{version.csv.first}"
+  desc "This cask follows releases from https://github.com/dotnet/core/tree/master"
+  homepage "https://www.microsoft.com/net/core#macos"
+
+  livecheck do
+    skip "See https://github.com/isen-ng/homebrew-dotnet-sdk-versions/blob/master/CONTRIBUTING.md#automatic-updates"
+  end
+
+  depends_on macos: ">= :mojave"
+
+  pkg "dotnet-sdk-#{version.csv.first}-osx-#{arch}.pkg"
+
+  uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.csv.first}.component.osx.#{arch}"
+
+  zap trash:   ["~/.dotnet", "~/.nuget", "/etc/paths.d/dotnet", "/etc/paths.d/dotnet-cli-tools"],
+      pkgutil: [
+        "com.microsoft.dotnet.hostfxr.#{version.csv.second}.component.osx.#{arch}",
+        "com.microsoft.dotnet.sharedframework.Microsoft.NETCore.App.#{version.csv.second}.component.osx.#{arch}",
+        "com.microsoft.dotnet.pack.apphost.#{version.csv.second}.component.osx.#{arch}",
+        "com.microsoft.dotnet.sharedhost.component.osx.#{arch}",
+      ]
+
+  caveats "Uninstalling the offical dotnet-sdk casks will remove the shared runtime dependencies, " \
+          "so you\'ll need to reinstall the particular version cask you want from this tap again " \
+          "for the `dotnet` command to work again."
+end

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ dotnet --list-sdks
 
 | Version             | DotNet SDK     | Arch        | Remarks
 |---------------------|----------------|-------------|---------
+| `dotnet-sdk7-0-100` | dotnet 7.0.100 | x64 & arm64 |
 | `dotnet-sdk6-0-400` | dotnet 6.0.403 | x64 & arm64 |
 | `dotnet-sdk6-0-300` | dotnet 6.0.303 | x64 & arm64 |
 | `dotnet-sdk6-0-200` | dotnet 6.0.202 | x64 & arm64 |


### PR DESCRIPTION
This PR adds support for .NET SDK 7.0 (7.0.100).

```
basilfx:homebrew-dotnet-sdk-versions/ (feature/dotnet-sdk7) $ dotnet --list-sdks
3.1.424 [/usr/local/share/dotnet/sdk]
6.0.402 [/usr/local/share/dotnet/sdk]
7.0.100 [/usr/local/share/dotnet/sdk]
```

I don't have an ARM-capable CPU, but I double-checked the URLs.

I chose to only delete the preview version in the README.md, but leave the section as-is.