### PR TITLE
Add dotnet-sdk7-0-200

### DIFF
--- a/Casks/dotnet-sdk7-0-200.rb
+++ b/Casks/dotnet-sdk7-0-200.rb
@@ -1,0 +1,46 @@
+cask "dotnet-sdk7-0-200" do
+  arch arm: "arm64", intel: "x64"
+
+  version "7.0.202,7.0.4"
+
+  sha256_x64 = "31e48e3bddddd7e30f839b949608c80994dd6172e4fd025f2789c31a48d93f5b"
+  sha256_arm64 = "48a45898dc3e3a92f91f9e10c7d17a657e55399669e4cdf1917f1649c2338444"
+
+  url_x64 = "https://download.visualstudio.microsoft.com/download/pr/a87236b2-9ddd-4f48-ac81-d8d07a7cdac2/91a91d1eac4d598a6eaf5faf148f3afd/dotnet-sdk-#{version.csv.first}-osx-x64.pkg"
+  url_arm64 = "https://download.visualstudio.microsoft.com/download/pr/d569fc95-64b5-4fc3-ae06-5d3bec40e540/7532a322362c4717fc57211eafe5002c/dotnet-sdk-#{version.csv.first}-osx-arm64.pkg"
+
+  on_intel do
+    sha256 sha256_x64
+    url url_x64
+  end
+  on_arm do
+    sha256 sha256_arm64
+    url url_arm64
+  end
+
+  name ".NET Core SDK #{version.csv.first}"
+  desc "This cask follows releases from https://github.com/dotnet/core/tree/master"
+  homepage "https://www.microsoft.com/net/core#macos"
+
+  livecheck do
+    skip "See https://github.com/isen-ng/homebrew-dotnet-sdk-versions/blob/master/CONTRIBUTING.md#automatic-updates"
+  end
+
+  depends_on macos: ">= :mojave"
+
+  pkg "dotnet-sdk-#{version.csv.first}-osx-#{arch}.pkg"
+
+  uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.csv.first}.component.osx.#{arch}"
+
+  zap trash:   ["~/.dotnet", "~/.nuget", "/etc/paths.d/dotnet", "/etc/paths.d/dotnet-cli-tools"],
+      pkgutil: [
+        "com.microsoft.dotnet.hostfxr.#{version.csv.second}.component.osx.#{arch}",
+        "com.microsoft.dotnet.sharedframework.Microsoft.NETCore.App.#{version.csv.second}.component.osx.#{arch}",
+        "com.microsoft.dotnet.pack.apphost.#{version.csv.second}.component.osx.#{arch}",
+        "com.microsoft.dotnet.sharedhost.component.osx.#{arch}",
+      ]
+
+  caveats "Uninstalling the offical dotnet-sdk casks will remove the shared runtime dependencies, " \
+          "so you'll need to reinstall the particular version cask you want from this tap again " \
+          "for the `dotnet` command to work again."
+end

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ dotnet --list-sdks
 
 | Version             | DotNet SDK     | Arch        | Remarks
 |---------------------|----------------|-------------|---------
+| `dotnet-sdk7-0-200` | dotnet 7.0.202 | x64 & arm64 |
 | `dotnet-sdk7-0-100` | dotnet 7.0.102 | x64 & arm64 |
 | `dotnet-sdk6-0-400` | dotnet 6.0.406 | x64 & arm64 |
 | `dotnet-sdk6-0-300` | dotnet 6.0.303 | x64 & arm64 |


### PR DESCRIPTION
This PR adds support for .NET SDK 7.0.4 (7.0.202).

```
basilfx:homebrew-dotnet-sdk-versions/ (feature/dotnet-sdk7) $ dotnet --list-sdks
3.1.425 [/usr/local/share/dotnet/sdk]
6.0.403 [/usr/local/share/dotnet/sdk]
7.0.202 [/usr/local/share/dotnet/sdk]
```