### PR TITLE
Add dotnet-sdk7-0-300

### DIFF
--- a/Casks/dotnet-sdk7-0-300.rb
+++ b/Casks/dotnet-sdk7-0-300.rb
@@ -1,0 +1,47 @@
+cask "dotnet-sdk7-0-300" do
+  arch arm: "arm64", intel: "x64"
+
+  version "7.0.304,7.0.7"
+
+  sha256_x64 = "a1abd5a89b7c7ec309c211fc69654c7d30d3279b9be9fe59b0d4a72a61da0fd7"
+  sha256_arm64 = "788f125b3ce3cae7e24afca788d60704cb115d0ea5c2cde088038db1f1eb0619"
+  url_x64 = "https://download.visualstudio.microsoft.com/download/pr/6e4a2a04-483d-42d4-8cbd-27257c47a8bf/52917aad4fb720797c351e38fb706531/dotnet-sdk-#{version.csv.first}-osx-x64.pkg"
+  url_arm64 = "https://download.visualstudio.microsoft.com/download/pr/53f2dc54-c56d-4bc2-b7ac-4705565f1f58/ce10a5e5e5ed4acf1ea3caf443ecbd2e/dotnet-sdk-#{version.csv.first}-osx-arm64.pkg"
+
+  on_arm do
+    sha256 sha256_arm64
+
+    url url_arm64
+  end
+  on_intel do
+    sha256 sha256_x64
+
+    url url_x64
+  end
+
+  name ".NET Core SDK #{version.csv.first}"
+  desc "This cask follows releases from https://github.com/dotnet/core/tree/master"
+  homepage "https://www.microsoft.com/net/core#macos"
+
+  livecheck do
+    skip "See https://github.com/isen-ng/homebrew-dotnet-sdk-versions/blob/master/CONTRIBUTING.md#automatic-updates"
+  end
+
+  depends_on macos: ">= :mojave"
+
+  pkg "dotnet-sdk-#{version.csv.first}-osx-#{arch}.pkg"
+
+  uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.csv.first}.component.osx.#{arch}"
+
+  zap trash:   ["~/.dotnet", "~/.nuget", "/etc/paths.d/dotnet", "/etc/paths.d/dotnet-cli-tools"],
+      pkgutil: [
+        "com.microsoft.dotnet.hostfxr.#{version.csv.second}.component.osx.#{arch}",
+        "com.microsoft.dotnet.sharedframework.Microsoft.NETCore.App.#{version.csv.second}.component.osx.#{arch}",
+        "com.microsoft.dotnet.pack.apphost.#{version.csv.second}.component.osx.#{arch}",
+        "com.microsoft.dotnet.sharedhost.component.osx.#{arch}",
+      ]
+
+  caveats "Uninstalling the offical dotnet-sdk casks will remove the shared runtime dependencies, " \
+          "so you'll need to reinstall the particular version cask you want from this tap again " \
+          "for the `dotnet` command to work again."
+end

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ dotnet --list-sdks
 
 | Version             | DotNet SDK     | Arch        | Remarks
 |---------------------|----------------|-------------|---------
+| `dotnet-sdk7-0-300` | dotnet 7.0.304 | x64 & arm64 |
 | `dotnet-sdk7-0-200` | dotnet 7.0.203 | x64 & arm64 |
 | `dotnet-sdk7-0-100` | dotnet 7.0.102 | x64 & arm64 |
 | `dotnet-sdk6-0-400` | dotnet 6.0.408 | x64 & arm64 |


### PR DESCRIPTION
This PR adds support for .NET SDK 7.0.7 (7.0.304).

```
basilfx:homebrew-dotnet-sdk-versions/ (feature/dotnet-sdk7-300) $ dotnet --list-sdks
3.1.426 [/usr/local/share/dotnet/sdk]
6.0.408 [/usr/local/share/dotnet/sdk]
7.0.304 [/usr/local/share/dotnet/sdk]
```