### PR TITLE
Add dotnet-sdk7-0-400

### DIFF
--- a/Casks/dotnet-sdk7-0-400.rb
+++ b/Casks/dotnet-sdk7-0-400.rb
@@ -1,0 +1,47 @@
+cask "dotnet-sdk7-0-400" do
+  arch arm: "arm64", intel: "x64"
+
+  version "7.0.400,7.0.10"
+
+  sha256_x64 = "058b3d135221ee4814211d320934d181dec2a07dd305d07513336ba3ffec8846"
+  sha256_arm64 = "e00d9505312d8819baafa45f5676b1825e85cef86ff77d0fd2828c2c750a0c71"
+  url_x64 = "https://download.visualstudio.microsoft.com/download/pr/f4c17ae1-56c5-4d79-8ce2-31c46a861a96/e39ebd96c092d4acb394c864aa0c8eaa/dotnet-sdk-#{version.csv.first}-osx-x64.pkg"
+  url_arm64 = "https://download.visualstudio.microsoft.com/download/pr/006fcd0f-5c39-462b-8425-8af5c66915d0/de20d3b86725a79b7d0de0f3f9c86b05/dotnet-sdk-#{version.csv.first}-osx-arm64.pkg"
+
+  on_arm do
+    sha256 sha256_arm64
+
+    url url_arm64
+  end
+  on_intel do
+    sha256 sha256_x64
+
+    url url_x64
+  end
+
+  name ".NET Core SDK #{version.csv.first}"
+  desc "This cask follows releases from https://github.com/dotnet/core/tree/master"
+  homepage "https://www.microsoft.com/net/core#macos"
+
+  livecheck do
+    skip "See https://github.com/isen-ng/homebrew-dotnet-sdk-versions/blob/master/CONTRIBUTING.md#automatic-updates"
+  end
+
+  depends_on macos: ">= :mojave"
+
+  pkg "dotnet-sdk-#{version.csv.first}-osx-#{arch}.pkg"
+
+  uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.csv.first}.component.osx.#{arch}"
+
+  zap trash:   ["~/.dotnet", "~/.nuget", "/etc/paths.d/dotnet", "/etc/paths.d/dotnet-cli-tools"],
+      pkgutil: [
+        "com.microsoft.dotnet.hostfxr.#{version.csv.second}.component.osx.#{arch}",
+        "com.microsoft.dotnet.sharedframework.Microsoft.NETCore.App.#{version.csv.second}.component.osx.#{arch}",
+        "com.microsoft.dotnet.pack.apphost.#{version.csv.second}.component.osx.#{arch}",
+        "com.microsoft.dotnet.sharedhost.component.osx.#{arch}",
+      ]
+
+  caveats "Uninstalling the offical dotnet-sdk casks will remove the shared runtime dependencies, " \
+          "so you'll need to reinstall the particular version cask you want from this tap again " \
+          "for the `dotnet` command to work again."
+end

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ dotnet --list-sdks
 
 | Version             | DotNet SDK     | Arch        | Remarks
 |---------------------|----------------|-------------|---------
+| `dotnet-sdk7-0-400` | dotnet 7.0.400 | x64 & arm64 |
 | `dotnet-sdk7-0-300` | dotnet 7.0.306 | x64 & arm64 |
 | `dotnet-sdk7-0-200` | dotnet 7.0.203 | x64 & arm64 |
 | `dotnet-sdk7-0-100` | dotnet 7.0.102 | x64 & arm64 |


### PR DESCRIPTION
This PR adds support for .NET SDK 7.0.10 (7.0.400).

```
basilfx:homebrew-dotnet-sdk-versions/ (feature/dotnet-sdk7-400) $ dotnet --list-sdks
3.1.426 [/usr/local/share/dotnet/sdk]
6.0.411 [/usr/local/share/dotnet/sdk]
7.0.400 [/usr/local/share/dotnet/sdk]
```