### PR TITLE
Update dotnet sdk8 cask

### DIFF
--- a/Casks/dotnet-sdk3.rb
+++ b/Casks/dotnet-sdk3.rb
@@ -2,10 +2,10 @@ cask "dotnet-sdk3" do
   version "3.1.426,3.1.32"
   sha256 :no_check
 
-  url "https://github.com/fluffynuts/homebrew-dotnet-sdk-versions/raw/master/META.md"
+  url "https://github.com/isen-ng/homebrew-dotnet-sdk-versions/raw/master/META.md"
   name ".NET Core SDK #{version.csv.first}"
   desc "This cask follows releases from https://github.com/dotnet/core/tree/master"
-  homepage "https://github.com/fluffynuts/homebrew-dotnet-sdk-versions"
+  homepage "https://github.com/isen-ng/homebrew-dotnet-sdk-versions"
 
   depends_on cask: "dotnet-sdk3-1-400"
   depends_on macos: ">= :high_sierra"

--- a/Casks/dotnet-sdk5.rb
+++ b/Casks/dotnet-sdk5.rb
@@ -2,10 +2,10 @@ cask "dotnet-sdk5" do
   version "5.0.408,5.0.17"
   sha256 :no_check
 
-  url "https://github.com/fluffynuts/homebrew-dotnet-sdk-versions/raw/master/META.md"
+  url "https://github.com/isen-ng/homebrew-dotnet-sdk-versions/raw/master/META.md"
   name ".NET Core SDK #{version.csv.first}"
   desc "This cask follows releases from https://github.com/dotnet/core/tree/master"
-  homepage "https://github.com/fluffynuts/homebrew-dotnet-sdk-versions"
+  homepage "https://github.com/isen-ng/homebrew-dotnet-sdk-versions"
 
   depends_on cask: "dotnet-sdk5-0-400"
   depends_on macos: ">= :high_sierra"

--- a/Casks/dotnet-sdk6.rb
+++ b/Casks/dotnet-sdk6.rb
@@ -4,10 +4,10 @@ cask "dotnet-sdk6" do
   version "6.0.419,6.0.27"
   sha256 :no_check
 
-  url "https://github.com/fluffynuts/homebrew-dotnet-sdk-versions/raw/master/META.md"
+  url "https://github.com/isen-ng/homebrew-dotnet-sdk-versions/raw/master/META.md"
   name ".NET Core SDK #{version.csv.first}"
   desc "This cask follows releases from https://github.com/dotnet/core/tree/master"
-  homepage "https://github.com/fluffynuts/homebrew-dotnet-sdk-versions"
+  homepage "https://github.com/isen-ng/homebrew-dotnet-sdk-versions"
 
   depends_on cask: "dotnet-sdk6-0-400"
   depends_on macos: ">= :mojave"

--- a/Casks/dotnet-sdk7.rb
+++ b/Casks/dotnet-sdk7.rb
@@ -4,10 +4,10 @@ cask "dotnet-sdk7" do
   version "7.0.406,7.0.16"
   sha256 :no_check
 
-  url "https://github.com/fluffynuts/homebrew-dotnet-sdk-versions/raw/master/META.md"
+  url "https://github.com/isen-ng/homebrew-dotnet-sdk-versions/raw/master/META.md"
   name ".NET Core SDK #{version.csv.first}"
   desc "This cask follows releases from https://github.com/dotnet/core/tree/master"
-  homepage "https://github.com/fluffynuts/homebrew-dotnet-sdk-versions"
+  homepage "https://github.com/isen-ng/homebrew-dotnet-sdk-versions"
 
   depends_on cask: "dotnet-sdk7-0-400"
   depends_on macos: ">= :mojave"

--- a/Casks/dotnet-sdk8.rb
+++ b/Casks/dotnet-sdk8.rb
@@ -1,15 +1,15 @@
 cask "dotnet-sdk8" do
   arch arm: "arm64", intel: "x64"
 
-  version "8.0.101,8.0.1"
+  version "8.0.200,8.0.2"
   sha256 :no_check
 
-  url "https://github.com/fluffynuts/homebrew-dotnet-sdk-versions/raw/master/META.md"
+  url "https://github.com/isen-ng/homebrew-dotnet-sdk-versions/raw/master/META.md"
   name ".NET Core SDK #{version.csv.first}"
   desc "This cask follows releases from https://github.com/dotnet/core/tree/master"
-  homepage "https://github.com/fluffynuts/homebrew-dotnet-sdk-versions"
+  homepage "https://github.com/isen-ng/homebrew-dotnet-sdk-versions"
 
-  depends_on cask: "dotnet-sdk8-0-100"
+  depends_on cask: "dotnet-sdk8-0-200"
   depends_on macos: ">= :catalina"
 
   stage_only true

--- a/Casks/dotnet-sdk8.rb
+++ b/Casks/dotnet-sdk8.rb
@@ -1,7 +1,7 @@
 cask "dotnet-sdk8" do
   arch arm: "arm64", intel: "x64"
 
-  version "8.0.200,8.0.2"
+  version "8.0.201,8.0.2"
   sha256 :no_check
 
   url "https://github.com/isen-ng/homebrew-dotnet-sdk-versions/raw/master/META.md"


### PR DESCRIPTION
Default the dotnet-sdk8 cask to the latest version of https://github.com/isen-ng/homebrew-dotnet-sdk-versions/pull/315

- Bump default dotnet 8 cask to 8.0.201
- Fix all the incorrect links to a forked repo that should be pointing to this repo