### PR TITLE
feat: try add dotnet-sdk10-preview

### DIFF
--- a/Casks/dotnet-sdk10-preview.rb
+++ b/Casks/dotnet-sdk10-preview.rb
@@ -3,18 +3,18 @@ cask "dotnet-sdk10-preview" do
 
   version "10.0.100-preview.1.25120.13"
 
-  sha512_x64 = "29900a2b93424661ba0300671be017629ca5c5183cdddbeaecae2666f8a5ea6c26e415b7f2286a6644efa27523ebb0f61080b9fad82f85dc9c648344af36268d"
-  sha512_arm64 = "14f83d81cbafcc572a70100037c677911368970e4b20dd471d69595813b688615577b393cb4f8579b284493341b7642ad2f2d00171dd9d1d40d35e886e2ed2dc"
+  sha256_x64 = "29900a2b93424661ba0300671be017629ca5c5183cdddbeaecae2666f8a5ea6c26e415b7f2286a6644efa27523ebb0f61080b9fad82f85dc9c648344af36268d"
+  sha256_arm64 = "14f83d81cbafcc572a70100037c677911368970e4b20dd471d69595813b688615577b393cb4f8579b284493341b7642ad2f2d00171dd9d1d40d35e886e2ed2dc"
   url_x64 = "https://download.visualstudio.microsoft.com/download/pr/80339095-1418-4792-9d81-d7b8dc44a436/d8f1d068666055023d1c98e6d4f8fd60/dotnet-sdk-#{version.csv.first}-osx-x64.pkg"
   url_arm64 = "https://download.visualstudio.microsoft.com/download/pr/a826c444-678e-487e-8c4e-ebfc14afca99/d22a35c78682369beb65d20afc995a7e/dotnet-sdk-#{version.csv.first}-osx-arm64.pkg"
 
   on_arm do
-    sha512 sha512_arm64
+    sha256 sha256_arm64
 
     url url_arm64
   end
   on_intel do
-    sha512 sha512_x64
+    sha256 sha256_x64
 
     url url_x64
   end

--- a/Casks/dotnet-sdk10-preview.rb
+++ b/Casks/dotnet-sdk10-preview.rb
@@ -3,8 +3,8 @@ cask "dotnet-sdk10-preview" do
 
   version "10.0.100-preview.1.25120.13"
 
-  sha256_x64 = "29900a2b93424661ba0300671be017629ca5c5183cdddbeaecae2666f8a5ea6c26e415b7f2286a6644efa27523ebb0f61080b9fad82f85dc9c648344af36268d"
-  sha256_arm64 = "14f83d81cbafcc572a70100037c677911368970e4b20dd471d69595813b688615577b393cb4f8579b284493341b7642ad2f2d00171dd9d1d40d35e886e2ed2dc"
+  sha256_x64 = "fb9891063e3f27df0ee9748e7a1b0fb66bb8f89b510451fd8f2537ff915792bc"
+  sha256_arm64 = "d243a9fee935da7a37819c338b41ef28186c43594d76a89d52be757dda073b04"
   url_x64 = "https://download.visualstudio.microsoft.com/download/pr/80339095-1418-4792-9d81-d7b8dc44a436/d8f1d068666055023d1c98e6d4f8fd60/dotnet-sdk-#{version.csv.first}-osx-x64.pkg"
   url_arm64 = "https://download.visualstudio.microsoft.com/download/pr/a826c444-678e-487e-8c4e-ebfc14afca99/d22a35c78682369beb65d20afc995a7e/dotnet-sdk-#{version.csv.first}-osx-arm64.pkg"
 

--- a/Casks/dotnet-sdk10-preview.rb
+++ b/Casks/dotnet-sdk10-preview.rb
@@ -1,0 +1,47 @@
+cask "dotnet-sdk10-preview" do
+  arch arm: "arm64", intel: "x64"
+
+  version "10.0.100-preview.1.25120.13"
+
+  sha512_x64 = "29900a2b93424661ba0300671be017629ca5c5183cdddbeaecae2666f8a5ea6c26e415b7f2286a6644efa27523ebb0f61080b9fad82f85dc9c648344af36268d"
+  sha512_arm64 = "14f83d81cbafcc572a70100037c677911368970e4b20dd471d69595813b688615577b393cb4f8579b284493341b7642ad2f2d00171dd9d1d40d35e886e2ed2dc"
+  url_x64 = "https://download.visualstudio.microsoft.com/download/pr/80339095-1418-4792-9d81-d7b8dc44a436/d8f1d068666055023d1c98e6d4f8fd60/dotnet-sdk-#{version.csv.first}-osx-x64.pkg"
+  url_arm64 = "https://download.visualstudio.microsoft.com/download/pr/a826c444-678e-487e-8c4e-ebfc14afca99/d22a35c78682369beb65d20afc995a7e/dotnet-sdk-#{version.csv.first}-osx-arm64.pkg"
+
+  on_arm do
+    sha512 sha512_arm64
+
+    url url_arm64
+  end
+  on_intel do
+    sha512 sha512_x64
+
+    url url_x64
+  end
+
+  name ".NET SDK #{version.csv.first}"
+  desc "This cask follows releases from https://github.com/dotnet/core/tree/master"
+  homepage "https://www.microsoft.com/net/core#macos"
+
+  livecheck do
+    skip "See https://github.com/isen-ng/homebrew-dotnet-sdk-versions/blob/master/CONTRIBUTING.md#automatic-updates"
+  end
+
+  depends_on macos: ">= :monterey"
+
+  pkg "dotnet-sdk-#{version.csv.first}-osx-#{arch}.pkg"
+
+  uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.csv.first}.component.osx.#{arch}"
+
+  zap pkgutil: [
+        "com.microsoft.dotnet.hostfxr.#{version.csv.second}.component.osx.#{arch}",
+        "com.microsoft.dotnet.pack.apphost.#{version.csv.second}.component.osx.#{arch}",
+        "com.microsoft.dotnet.sharedframework.Microsoft.NETCore.App.#{version.csv.second}.component.osx.#{arch}",
+        "com.microsoft.dotnet.sharedhost.component.osx.#{arch}",
+      ],
+      trash:   ["~/.dotnet", "~/.nuget", "/etc/paths.d/dotnet", "/etc/paths.d/dotnet-cli-tools"]
+
+  caveats "Uninstalling the offical dotnet-sdk casks will remove the shared runtime dependencies, " \
+          "so you'll need to reinstall the particular version cask you want from this tap again " \
+          "for the `dotnet` command to work again."
+end

--- a/README.md
+++ b/README.md
@@ -75,11 +75,12 @@ after installing/upgrading to .NET SDK 5.
 
 ### Preview versions
 
-| Version               | .NET SDK                   | Arch        | Remarks |
-| --------------------- | -------------------------- | ----------- | ------- |
-| `dotnet-sdk9-preview` | 9.0.102-rc.2.24474.11      | x64 & arm64 |         |
-| `dotnet-sdk8-preview` | 8.0.101-rc.2.23502.2       | x64 & arm64 |         |
-| `dotnet-sdk7-preview` | 7.0.100-rc.2.22477.23      | x64 & arm64 |         |
+| Version                | .NET SDK                    | Arch        | Remarks |
+| ---------------------- | --------------------------- | ----------- | ------- |
+| `dotnet-sdk10-preview` | 10.0.100-preview.1.25120.13 | x64 & arm64 |         |
+| `dotnet-sdk9-preview`  | 9.0.102-rc.2.24474.11       | x64 & arm64 |         |
+| `dotnet-sdk8-preview`  | 8.0.101-rc.2.23502.2        | x64 & arm64 |         |
+| `dotnet-sdk7-preview`  | 7.0.100-rc.2.22477.23       | x64 & arm64 |         |
 
 
 ## Uninstalling


### PR DESCRIPTION
fixes #397 

try to add dotnet-sdk10-preview

from the download page, there's only sha512 now, so I simply update the sha256 to sha512, not sure if additional works need to be made

not sure how to test, only update the links and sha512 hash now from the dotnet9-sdk preview