### PR TITLE
Updates dotnet-sdk9 to 9.0.300

### DIFF
--- a/Casks/dotnet-sdk9-0-300.rb
+++ b/Casks/dotnet-sdk9-0-300.rb
@@ -1,0 +1,47 @@
+cask "dotnet-sdk9-0-300" do
+  arch arm: "arm64", intel: "x64"
+
+  version "9.0.300,9.0.5"
+
+  sha256_x64 = "557fb494d307a57094d18c3f5e4acae22fb5d79c0cf2921319ef6dd266cb6cce"
+  sha256_arm64 = "e40d0db5785aaadf4698bf7a3b5f8b8df8145e70e6619c0ebb57bd809b35c796"
+  url_x64 = "https://builds.dotnet.microsoft.com/dotnet/Sdk/#{version.csv.first}/dotnet-sdk-#{version.csv.first}-osx-x64.pkg"
+  url_arm64 = "https://builds.dotnet.microsoft.com/dotnet/Sdk/#{version.csv.first}/dotnet-sdk-#{version.csv.first}-osx-arm64.pkg"
+
+  on_arm do
+    sha256 sha256_arm64
+
+    url url_arm64
+  end
+  on_intel do
+    sha256 sha256_x64
+
+    url url_x64
+  end
+
+  name ".NET Core SDK #{version.csv.first}"
+  desc "This cask follows releases from https://github.com/dotnet/core/tree/master"
+  homepage "https://www.microsoft.com/net/core#macos"
+
+  livecheck do
+    skip "See https://github.com/isen-ng/homebrew-dotnet-sdk-versions/blob/master/CONTRIBUTING.md#automatic-updates"
+  end
+
+  depends_on macos: ">= :ventura"
+
+  pkg "dotnet-sdk-#{version.csv.first}-osx-#{arch}.pkg"
+
+  uninstall pkgutil: "com.microsoft.dotnet.dev.#{version.csv.first}.component.osx.#{arch}"
+
+  zap pkgutil: [
+        "com.microsoft.dotnet.hostfxr.#{version.csv.second}.component.osx.#{arch}",
+        "com.microsoft.dotnet.pack.apphost.#{version.csv.second}.component.osx.#{arch}",
+        "com.microsoft.dotnet.sharedframework.Microsoft.NETCore.App.#{version.csv.second}.component.osx.#{arch}",
+        "com.microsoft.dotnet.sharedhost.component.osx.#{arch}",
+      ],
+      trash:   ["~/.dotnet", "~/.nuget", "/etc/paths.d/dotnet", "/etc/paths.d/dotnet-cli-tools"]
+
+  caveats "Uninstalling the offical dotnet-sdk casks will remove the shared runtime dependencies, " \
+          "so you'll need to reinstall the particular version cask you want from this tap again " \
+          "for the `dotnet` command to work again."
+end

--- a/Casks/dotnet-sdk9.rb
+++ b/Casks/dotnet-sdk9.rb
@@ -1,7 +1,7 @@
 cask "dotnet-sdk9" do
   arch arm: "arm64", intel: "x64"
 
-  version "9.0.203,9.0.4"
+  version "9.0.300,9.0.5"
   sha256 :no_check
 
   url "https://github.com/isen-ng/homebrew-dotnet-sdk-versions/raw/master/META.md"
@@ -9,7 +9,7 @@ cask "dotnet-sdk9" do
   desc "This cask follows releases from https://github.com/dotnet/core/tree/master"
   homepage "https://github.com/isen-ng/homebrew-dotnet-sdk-versions"
 
-  depends_on cask: "dotnet-sdk9-0-200"
+  depends_on cask: "dotnet-sdk9-0-300"
   depends_on macos: ">= :ventura"
 
   stage_only true

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ dotnet --list-sdks
 
 | Version       | .NET SDK |
 | ------------- | -------- |
-| `dotnet-sdk9` | 9.0.203  |
+| `dotnet-sdk9` | 9.0.300  |
 | `dotnet-sdk8` | 8.0.409  |
 | `dotnet-sdk7` | 7.0.410  |
 | `dotnet-sdk6` | 6.0.428  |
@@ -39,6 +39,7 @@ dotnet --list-sdks
 
 | Version             | .NET SDK | Arch        | Remarks                                  |
 | ------------------- | -------- | ----------- | ---------------------------------------- |
+| `dotnet-sdk9-0-300` | 9.0.300  | x64 & arm64 |                                          |
 | `dotnet-sdk9-0-200` | 9.0.203  | x64 & arm64 |                                          |
 | `dotnet-sdk9-0-100` | 9.0.102  | x64 & arm64 |                                          |
 | `dotnet-sdk8-0-400` | 8.0.409  | x64 & arm64 |                                          |


### PR DESCRIPTION
Updates the dotnet-sdk9 cask and its dependency to the 9.0.300 SDK.

This change ensures that the dotnet-sdk9 cask points to the latest available version, resolving potential compatibility issues and ensuring users have access to the newest features and bug fixes.